### PR TITLE
Unify indentation in configuration files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,26 +1,26 @@
 [flake8]
 filename =
-    ./scripts/*.py,
-    ./src/*.py,
-    ./tests/*.py
+  ./scripts/*.py,
+  ./src/*.py,
+  ./tests/*.py
 per-file-ignores =
-    scripts/*: D
-    tests/*: D
+  scripts/*: D
+  tests/*: D
 
 # Google docstring convention + D204 & D401
 docstring-convention = all
 ignore =
-    D100
-    D104
-    D203
-    D213
-    D215
-    D406
-    D407
-    D408
-    D409
-    D413
-    U101
+  D100
+  D104
+  D203
+  D213
+  D215
+  D406
+  D407
+  D408
+  D409
+  D413
+  U101
 
 max_line_length = 150
 unused-arguments-ignore-overload-functions = True

--- a/.github/workflows/lint_and_type_checks.yaml
+++ b/.github/workflows/lint_and_type_checks.yaml
@@ -12,19 +12,19 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: make install-dev
+      - name: Install dependencies
+        run: make install-dev
 
-    - name: Run lint
-      run: make lint
+      - name: Run lint
+        run: make lint
 
-    - name: Run type checks
-      run: make type-check
+      - name: Run type checks
+        run: make type-check

--- a/.github/workflows/pr_toolkit.yaml
+++ b/.github/workflows/pr_toolkit.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
       - master
-    types: ['opened', 'reopened', 'synchronize', 'labeled', 'unlabeled', 'edited', 'ready_for_review'] # The first 3 are default.
+    types: [opened, reopened, synchronize, labeled, unlabeled, edited, ready_for_review] # The first 3 are default.
 
 concurrency: # This is to make sure that it's executed only for the most recent changes of PR.
   group: ${{ github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
     tags-ignore:
-      - '**'
+      - "**"
   # A release via GitHub releases will publish a stable version
   release:
     types: [published]
@@ -14,14 +14,14 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type'
+        description: Release type
         required: true
         type: choice
-        default: 'alpha'
+        default: alpha
         options:
-          - 'alpha'
-          - 'beta'
-          - 'final'
+          - alpha
+          - beta
+          - final
 
 jobs:
   lint_and_type_checks:
@@ -44,73 +44,73 @@ jobs:
       url: https://pypi.org/p/apify-shared
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
 
-    - name: Install dependencies
-      run: make install-dev
+      - name: Install dependencies
+        run: make install-dev
 
-    - # Determine if this is a prerelease or latest release
-      name: Determine release type
-      id: get-release-type
-      run: |
-        if [ ${{ github.event_name }} = release ]; then
-          release_type="final"
-        elif [ ${{ github.event_name }} = push ]; then
-          release_type="beta"
-        elif [ ${{ github.event_name }} = workflow_dispatch ]; then
-          release_type=${{ github.event.inputs.release_type }}
-        fi
+      - # Determine if this is a prerelease or latest release
+        name: Determine release type
+        id: get-release-type
+        run: |
+          if [ ${{ github.event_name }} = release ]; then
+            release_type="final"
+          elif [ ${{ github.event_name }} = push ]; then
+            release_type="beta"
+          elif [ ${{ github.event_name }} = workflow_dispatch ]; then
+            release_type=${{ github.event.inputs.release_type }}
+          fi
 
-        if [ ${release_type} = final ]; then
-          docker_image_tag="latest"
-        elif [ ${release_type} = beta ]; then
-          docker_image_tag="beta"
-        else
-          docker_image_tag=""
-        fi
+          if [ ${release_type} = final ]; then
+            docker_image_tag="latest"
+          elif [ ${release_type} = beta ]; then
+            docker_image_tag="beta"
+          else
+            docker_image_tag=""
+          fi
 
-        echo "release_type=${release_type}" >> $GITHUB_OUTPUT
-        echo "docker_image_tag=${docker_image_tag}" >> $GITHUB_OUTPUT
+          echo "release_type=${release_type}" >> $GITHUB_OUTPUT
+          echo "docker_image_tag=${docker_image_tag}" >> $GITHUB_OUTPUT
 
-    - # Check whether the released version is listed in CHANGELOG.md
-      name: Check whether the released version is listed in the changelog
-      if: steps.get-release-type.outputs.release_type != 'alpha'
-      run: make check-changelog-entry
+      - # Check whether the released version is listed in CHANGELOG.md
+        name: Check whether the released version is listed in the changelog
+        if: steps.get-release-type.outputs.release_type != 'alpha'
+        run: make check-changelog-entry
 
-    - # Check version consistency and increment pre-release version number for prereleases (must be the last step before build)
-      name: Bump pre-release version
-      if: steps.get-release-type.outputs.release_type != 'final'
-      run: python ./scripts/update_version_for_prerelease.py ${{ steps.get-release-type.outputs.release_type }}
+      - # Check version consistency and increment pre-release version number for prereleases (must be the last step before build)
+        name: Bump pre-release version
+        if: steps.get-release-type.outputs.release_type != 'final'
+        run: python ./scripts/update_version_for_prerelease.py ${{ steps.get-release-type.outputs.release_type }}
 
-    - # Build a source distribution and a python3-only wheel
-      name: Build distribution files
-      run: make build
+      - # Build a source distribution and a python3-only wheel
+        name: Build distribution files
+        run: make build
 
-    - # Check whether the package description will render correctly on PyPI
-      name: Check package rendering on PyPI
-      run: make twine-check
+      - # Check whether the package description will render correctly on PyPI
+        name: Check package rendering on PyPI
+        run: make twine-check
 
-    - # Publish package to PyPI using their official GitHub action
-      name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - # Publish package to PyPI using their official GitHub action
+        name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
-    - # Tag the current commit with the version tag if this is not made from the release event (releases are tagged with the release process)
-      name: Tag Version
-      if: github.event_name != 'release'
-      run: |
-        git_tag=v`python ./scripts/print_current_package_version.py`
-        git tag $git_tag
-        git push origin $git_tag
+      - # Tag the current commit with the version tag if this is not made from the release event (releases are tagged with the release process)
+        name: Tag Version
+        if: github.event_name != 'release'
+        run: |
+          git_tag=v`python ./scripts/print_current_package_version.py`
+          git tag $git_tag
+          git push origin $git_tag
 
-    - # Upload the build artifacts to the release
-      name: Upload the build artifacts to release
-      if: github.event_name == 'release'
-      run: gh release upload ${{ github.ref_name }} dist/*
-      env:
-        GH_TOKEN: ${{ github.token }}
+      - # Upload the build artifacts to the release
+        name: Upload the build artifacts to release
+        if: github.event_name == 'release'
+        run: gh release upload ${{ github.ref_name }} dist/*
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,26 @@
 repos:
-- repo: local
-  hooks:
-    - id: lint
-      name: "Lint codebase"
-      entry: "make lint"
-      language: system
-      pass_filenames: false
+  - repo: local
+    hooks:
+      - id: lint
+        name: Lint codebase
+        entry: make lint
+        language: system
+        pass_filenames: false
 
-    - id: type-check
-      name: "Type-check codebase"
-      entry: "make type-check"
-      language: system
-      pass_filenames: false
+      - id: type-check
+        name: Type-check codebase
+        entry: make type-check
+        language: system
+        pass_filenames: false
 
-    - id: unit-tests
-      name: "Run unit tests"
-      entry: "make unit-tests"
-      language: system
-      pass_filenames: false
+      - id: unit-tests
+        name: Run unit tests
+        entry: make unit-tests
+        language: system
+        pass_filenames: false
 
-    - id: check-changelog
-      name: "Check whether current version is mentioned in changelog"
-      entry: "make check-changelog-entry"
-      language: system
-      pass_filenames: false
+      - id: check-changelog
+        name: Check whether current version is mentioned in changelog
+        entry: make check-changelog-entry
+        language: system
+        pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.3](../../releases/tag/v1.0.3) - 2023-08-04
+
+### Internal changes
+
+- Versions are 2nd level headings in the changelog.
+- Unify indentation in the configuration files.
+
 ## [1.0.2](../../releases/tag/v1.0.2) - 2023-08-02
 
 - Added the `ActorEnvVars` enum and new tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ license = {text = "Apache Software License"}
 name = "apify_shared"
 readme = "README.md"
 requires-python = ">=3.8"
-version = "1.0.2"
+version = "1.0.3"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
- Unnecessary quotes in YAML were removed.
- Currently, there were somewhere [single quotes](https://github.com/apify/apify-shared-python/blob/master/.github/workflows/release.yaml#L9), somewhere [double quotes](https://github.com/apify/apify-shared-python/blob/master/.github/workflows/lint_and_type_checks.yaml#L12) in the YAMLs. I converted all the singles to doubles since all other conf types use double quotes.
- Closes #7.