### PR TITLE
Stop using `pytest-randomly` in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.4](../../releases/tag/v1.0.4) - Unreleased
+
+### Internal changes
+
+- Removed `pytest-randomly` Pytest plugin
+
 ## [1.0.3](../../releases/tag/v1.0.3) - 2023-08-04
 
 ### Internal changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ license = { text = "Apache Software License" }
 name = "apify_shared"
 readme = "README.md"
 requires-python = ">=3.8"
-version = "1.0.3"
+version = "1.0.4"
 
 [project.optional-dependencies]
 dev = [
@@ -44,7 +44,6 @@ dev = [
     "pytest ~= 7.3.1",
     "pytest-asyncio ~= 0.21.0",
     "pytest-only ~= 2.0.0",
-    "pytest-randomly ~= 3.12.0",
     "pytest-timeout ~= 2.1.0",
     "pytest-xdist ~= 3.3.1",
     "twine ~= 4.0.2",


### PR DESCRIPTION
This removes the `pytest-randomly` Pytest plugin, as it doesn't play nice with `pytest-xdist`.

`pytest-randomly` (among other things) sets the random seed in the beginning of the tests to the current datetime. `pytest-xdist` runs the tests in parallel in multiple runners. When you use these two together, it happens that all of the runners have the same random seed, so if you e.g. [generate random resource names](https://github.com/apify/apify-client-python/blob/13c029e82731138cf67912fe6b375ab61846d4c5/tests/integration/test_request_queue.py#L7-L12), all runners will generate the same ones, leading to conflicts.

The other feature of `pytest-randomly`, running the tests in random order to ensure that the tests are not passing just because of some side effects caused by running in a specific order, does not work with `pytest-xdist` at all, so there are zero benefits of using `pytest-randomly` at all.