### PR TITLE
Relative imports were replaced for absolute imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [1.1.1](../../releases/tag/v1.1.1) - Unreleased
 
-...
+### Internal changes
+
+- Relative imports were replaced for absolute imports
 
 ## [1.1.0](../../releases/tag/v1.1.0) - 2023-11-16
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ ignore = [
     "S303",    # Use of insecure MD2, MD4, MD5, or SHA1 hash function
     "S311",    # Standard pseudo-random generators are not suitable for cryptographic purposes
     "TD002",   # Missing author in TODO; try: `# TODO(<author_name>): ...` or `# TODO @<author_name>: ...
-    "TID252",  # Relative imports from parent modules are bannedRuff
     "TRY003",  # Avoid specifying long messages outside the exception class
 ]
 
@@ -122,7 +121,7 @@ docstring-quotes = "double"
 inline-quotes = "single"
 
 [tool.ruff.lint.isort]
-known-first-party = ["apify", "apify_client", "apify_shared"]
+known-local-folder = ["apify_shared"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/apify_shared/models.py
+++ b/src/apify_shared/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Generic, TypeVar
 
-from .utils import ignore_docs
+from apify_shared.utils import ignore_docs
 
 T = TypeVar('T')
 


### PR DESCRIPTION
Only one case in the source code, in the unit tests there were absolute imports everywhere already. 

Closes: https://github.com/apify/apify-shared-python/issues/18.
