### PR TITLE
chore: add setuptools to opt deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "pytest-xdist ~= 3.3.1",
     "respx ~= 0.20.1",
     "ruff ~= 0.1.13",
+    "setuptools >= 68.0.0",
     "twine ~= 4.0.2",
 ]
 


### PR DESCRIPTION
This PR fixes GitHub actions for unit tests by adding setuptools as they are not pre-installed anymore. https://github.com/python/cpython/issues/95299