### PR TITLE
chore: bump `twine` to fix KeyError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
     "respx ~= 0.20.1",
     "ruff ~= 0.1.13",
     "setuptools >= 68.0.0",
-    "twine ~= 4.0.2",
+    "twine ~= 5.1.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
It seems that `twine` has problems because of dependency on `importlib-metadata`, hopefully `5.1.1` will fix it, see https://stackoverflow.com/a/78694674