### PR TITLE
chore: Move crypto_random_object_id to shared package

### DIFF
--- a/src/apify_shared/utils.py
+++ b/src/apify_shared/utils.py
@@ -4,6 +4,7 @@ import contextlib
 import io
 import json
 import re
+import secrets
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, TypeVar, cast
@@ -115,3 +116,9 @@ def parse_date_fields(data: ListOrDict, max_depth: int = PARSE_DATE_FIELDS_MAX_D
         return {key: parse(key, value) for (key, value) in data.items()}
 
     return data
+
+@ignore_docs
+def crypto_random_object_id(length: int = 17) -> str:
+    """Generates a random object ID."""
+    chars = 'abcdefghijklmnopqrstuvwxyzABCEDFGHIJKLMNOPQRSTUVWXYZ0123456789'
+    return ''.join(secrets.choice(chars) for _ in range(length))


### PR DESCRIPTION
Moving `crypto_random_object_id` to the shared python package as per https://github.com/apify/apify-client-python/pull/304#discussion_r1870839302 to be reused in crawlee and python client