### PR TITLE
fix: remove check-changelog pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,3 @@ repos:
         entry: make unit-tests
         language: system
         pass_filenames: false
-
-      - id: check-changelog
-        name: Check whether current version is mentioned in changelog
-        entry: make check-changelog-entry
-        language: system
-        pass_filenames: false


### PR DESCRIPTION
Now that the release process has been unified with other repos, this is not needed. And as the hook command actually no longer exists, this breaks contributions.