### PR TITLE
feat: add create_hmac_signature and create_storage_content_signature

### DIFF
--- a/src/apify_shared/utils.py
+++ b/src/apify_shared/utils.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
+import hmac
 import io
 import json
 import re
+import string
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, TypeVar, cast
@@ -115,3 +118,38 @@ def parse_date_fields(data: ListOrDict, max_depth: int = PARSE_DATE_FIELDS_MAX_D
         return {key: parse(key, value) for (key, value) in data.items()}
 
     return data
+
+
+CHARSET = string.digits + string.ascii_letters
+
+
+def encode_base62(num: int) -> str:
+    """Encode the given number to base62."""
+    if num == 0:
+        return CHARSET[0]
+
+    res = ''
+    while num > 0:
+        num, remainder = divmod(num, 62)
+        res = CHARSET[remainder] + res
+    return res
+
+
+@ignore_docs
+def create_hmac_signature(secret_key: str, message: str) -> str:
+    """Generates an HMAC signature and encodes it using Base62. Base62 encoding reduces the signature length.
+
+    HMAC signature is truncated to 30 characters to make it shorter.
+
+    Args:
+        secret_key (str): Secret key used for signing signatures
+        message (str): Message to be signed
+
+    Returns:
+        str: Base62 encoded signature
+    """
+    signature = hmac.new(secret_key.encode('utf-8'), message.encode('utf-8'), hashlib.sha256).hexdigest()[:30]
+
+    decimal_signature = int(signature, 16)
+
+    return encode_base62(decimal_signature)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -5,6 +5,8 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from apify_shared.utils import (
+    create_hmac_signature,
+    encode_base62,
     filter_out_none_values_recursively,
     filter_out_none_values_recursively_internal,
     ignore_docs,
@@ -146,3 +148,26 @@ def test_ignore_docs() -> None:
         return 'dummy'
 
     assert testing_function is ignore_docs(testing_function)
+
+
+def test_encode_base62() -> None:
+    assert encode_base62(0) == '0'
+    assert encode_base62(10) == 'a'
+    assert encode_base62(999999999) == '15FTGf'
+
+
+# This test ensures compatibility with the JavaScript version of the same method.
+# https://github.com/apify/apify-shared-js/blob/master/packages/utilities/src/hmac.ts
+def test_create_valid_hmac_signature() -> None:
+    # This test uses the same secret key and message as in JS tests.
+    secret_key = 'hmac-secret-key'
+    message = 'hmac-message-to-be-authenticated'
+    assert create_hmac_signature(secret_key, message) == 'pcVagAsudj8dFqdlg7mG'
+
+
+def test_create_same_hmac() -> None:
+    # This test uses the same secret key and message as in JS tests.
+    secret_key = 'hmac-same-secret-key'
+    message = 'hmac-same-message-to-be-authenticated'
+    assert create_hmac_signature(secret_key, message) == 'FYMcmTIm3idXqleF1Sw5'
+    assert create_hmac_signature(secret_key, message) == 'FYMcmTIm3idXqleF1Sw5'


### PR DESCRIPTION
This PR adds 2 new shared packages:
- `create_hmac_signature` - function moved from Apify SDK.
- `create_storage_content_signature` - function moved from Apify Client.

Those functions will be used in both - client and SDK, this is the reason of moving it into shared package