### PR TITLE
ci: Improve shared python workflows

### DIFF
--- a/.github/workflows/_check_code.yaml
+++ b/.github/workflows/_check_code.yaml
@@ -28,12 +28,12 @@ jobs:
 
   lint_check:
     name: Lint check
-    uses: apify/workflows/.github/workflows/python_lint_check.yaml@main
+    uses: apify/workflows/.github/workflows/python_lint_check.yaml@improve-shared-python-workflows
     with:
-      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
 
   type_check:
     name: Type check
-    uses: apify/workflows/.github/workflows/python_type_check.yaml@main
+    uses: apify/workflows/.github/workflows/python_type_check.yaml@improve-shared-python-workflows
     with:
-      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'

--- a/.github/workflows/_check_code.yaml
+++ b/.github/workflows/_check_code.yaml
@@ -28,12 +28,12 @@ jobs:
 
   lint_check:
     name: Lint check
-    uses: apify/workflows/.github/workflows/python_lint_check.yaml@improve-shared-python-workflows
+    uses: apify/workflows/.github/workflows/python_lint_check.yaml@main
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
 
   type_check:
     name: Type check
-    uses: apify/workflows/.github/workflows/python_type_check.yaml@improve-shared-python-workflows
+    uses: apify/workflows/.github/workflows/python_type_check.yaml@main
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'

--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -10,10 +10,9 @@ on:
 jobs:
   unit_tests:
     name: Unit tests
-    uses: apify/workflows/.github/workflows/python_unit_tests.yaml@main
+    uses: apify/workflows/.github/workflows/python_unit_tests.yaml@improve-shared-python-workflows
     with:
-      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
-      operating-systems: '["ubuntu-latest", "windows-latest"]'
-      # Apify shared don't use codecov, but we have to provide these inputs.
-      python-version-for-codecov: "3.14"
-      operating-system-for-codecov: ubuntu-latest
+      python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      operating_systems: '["ubuntu-latest", "windows-latest"]'
+      tests_concurrency: "1"
+      # Codecov inputs omitted - apify-shared-python doesn't use codecov.

--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   unit_tests:
     name: Unit tests
-    uses: apify/workflows/.github/workflows/python_unit_tests.yaml@improve-shared-python-workflows
+    uses: apify/workflows/.github/workflows/python_unit_tests.yaml@main
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       operating_systems: '["ubuntu-latest", "windows-latest"]'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,10 +95,10 @@ docstring-quotes = "double"
 inline-quotes = "single"
 
 [tool.pytest.ini_options]
-addopts = "-ra"
+addopts = "-r a --verbose"
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto"
-timeout = 300
+timeout = 1800
 
 [tool.ty.environment]
 python-version = "3.10"
@@ -111,11 +111,11 @@ include = ["src", "tests", "scripts", "docs", "website"]
 clean = "rm -rf .coverage .pytest_cache .ruff_cache .ty_cache build dist htmlcov"
 install-sync = "uv sync --all-extras"
 install-dev = "uv sync --all-extras"
-build = "uv build --verbose"
-publish-to-pypi = "uv publish --verbose --token ${APIFY_PYPI_TOKEN_CRAWLEE}"
+build = "uv build"
+publish-to-pypi = "uv publish --token ${APIFY_PYPI_TOKEN_CRAWLEE}"
 type-check = "uv run ty check"
-unit-tests = "uv run pytest --numprocesses=auto --verbose --cov=src/apify_shared tests/unit"
-unit-tests-cov = "uv run pytest --numprocesses=auto --verbose --cov=src/apify_shared --cov-report=html tests/unit"
+unit-tests = "uv run pytest --numprocesses=${TESTS_CONCURRENCY:-auto} --cov=src/apify_shared tests/unit"
+unit-tests-cov = "uv run pytest --numprocesses=${TESTS_CONCURRENCY:-auto} --cov=src/apify_shared --cov-report=html tests/unit"
 check-code = ["lint", "type-check", "unit-tests"]
 
 [tool.poe.tasks.lint]


### PR DESCRIPTION
Workflow improvements:
- Update shared workflow input names to snake_case
- Add tests_concurrency input for controlling parallel test execution
- Use @improve-shared-python-workflows branch for testing
- Remove unnecessary codecov inputs (now optional in shared workflow)

Pytest configuration:
- Standardize addopts to "-r a --verbose"
- Set timeout to 1800 seconds
- Use TESTS_CONCURRENCY env var in poe tasks (default: auto)