### PR TITLE
ci: remove release concurrency group from on_master.yaml

### DIFF
--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -7,10 +7,6 @@ on:
     tags-ignore:
       - "**" # Ignore all tags to avoid duplicate executions triggered by tag pushes.
 
-concurrency:
-  group: release
-  cancel-in-progress: false
-
 jobs:
   code_checks:
     name: Code checks


### PR DESCRIPTION
## Summary

The `on_master.yaml` workflow dispatches `manual_release_beta.yaml` and waits for it to finish, but both used the same `release` concurrency group with `cancel-in-progress: false`. Result: the dispatched run sat in `pending` forever while the parent held the slot — classic deadlock (see [this stuck run](https://github.com/apify/apify-client-python/actions/runs/25493818348/job/74808676838)).

Removing `concurrency` from `on_master.yaml` fixes it. `manual_release_beta.yaml` and `manual_release_stable.yaml` still share the `release` group, so serialization between actual releases is preserved.