### PR TITLE
build: limit sdist contents to source and metadata files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,16 @@ dev = [
     "ty~=0.0.0",
 ]
 
+[tool.hatch.build.targets.sdist]
+only-include = [
+    "src/apify_shared",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "README.md",
+    "pyproject.toml",
+]
+
 [tool.ruff]
 line-length = 120
 include = ["src/**/*.py", "tests/**/*.py"]


### PR DESCRIPTION
## Summary

Mirrors apify/crawlee-python#1890.

The latest crawlee-python beta release failed when uploading the sdist:

```
400 Bad Request — Project size too large. Limit for project 'crawlee' total size is 10 GB.
```

`pyproject.toml` only configured the wheel target, so hatchling's default sdist bundled the entire repo. Each released sdist was much larger than the actual source. Combined with the fact that a beta release is published on every src-touching commit to master, the cumulative storage quota on PyPI hit the cap fast.

This PR applies the same fix here: an explicit `[tool.hatch.build.targets.sdist]` that ships only `src/apify_shared` and standard metadata files (`CHANGELOG.md`, `CONTRIBUTING.md`, `LICENSE`, `README.md`, `pyproject.toml`). Verified locally: built sdist is ~17 KB and contains only those files.

Tests are intentionally excluded — they need dev-only deps that aren't installable from a plain sdist anyway.

## Note

PyPI's cap is cumulative across all uploaded files, so the eventual mitigation requires a [project size limit increase](https://docs.pypi.org/project-management/storage-limits#requesting-a-project-size-limit-increase) once a project hits its quota. This PR just keeps future releases from chewing through quota.